### PR TITLE
Favour i3ipc over i3 msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ i3-resurrect restore -w 1
 ```
 # Save workspace mode.
 mode "save" {
-  bindsym 1 exec "i3-resurrect save -w 1"
-  bindsym 2 exec "i3-resurrect save -w 2"
-  bindsym 3 exec "i3-resurrect save -w 3"
-  bindsym 4 exec "i3-resurrect save -w 4"
-  bindsym 5 exec "i3-resurrect save -w 5"
-  bindsym 6 exec "i3-resurrect save -w 6"
-  bindsym 7 exec "i3-resurrect save -w 7"
-  bindsym 8 exec "i3-resurrect save -w 8"
-  bindsym 9 exec "i3-resurrect save -w 9"
-  bindsym 0 exec "i3-resurrect save -w 0"
+  bindsym 1 exec i3-resurrect save -w 1
+  bindsym 2 exec i3-resurrect save -w 2
+  bindsym 3 exec i3-resurrect save -w 3
+  bindsym 4 exec i3-resurrect save -w 4
+  bindsym 5 exec i3-resurrect save -w 5
+  bindsym 6 exec i3-resurrect save -w 6
+  bindsym 7 exec i3-resurrect save -w 7
+  bindsym 8 exec i3-resurrect save -w 8
+  bindsym 9 exec i3-resurrect save -w 9
+  bindsym 0 exec i3-resurrect save -w 0
 
   # Back to normal: Enter, Escape, or s
   bindsym Return mode "default"
@@ -121,16 +121,16 @@ bindsym $mod+s mode "save"
 
 # Restore workspace mode.
 mode "restore" {
-  bindsym 1 exec "i3-resurrect restore -w 1"
-  bindsym 2 exec "i3-resurrect restore -w 2"
-  bindsym 3 exec "i3-resurrect restore -w 3"
-  bindsym 4 exec "i3-resurrect restore -w 4"
-  bindsym 5 exec "i3-resurrect restore -w 5"
-  bindsym 6 exec "i3-resurrect restore -w 6"
-  bindsym 7 exec "i3-resurrect restore -w 7"
-  bindsym 8 exec "i3-resurrect restore -w 8"
-  bindsym 9 exec "i3-resurrect restore -w 9"
-  bindsym 0 exec "i3-resurrect restore -w 0"
+  bindsym 1 exec i3-resurrect restore -w 1
+  bindsym 2 exec i3-resurrect restore -w 2
+  bindsym 3 exec i3-resurrect restore -w 3
+  bindsym 4 exec i3-resurrect restore -w 4
+  bindsym 5 exec i3-resurrect restore -w 5
+  bindsym 6 exec i3-resurrect restore -w 6
+  bindsym 7 exec i3-resurrect restore -w 7
+  bindsym 8 exec i3-resurrect restore -w 8
+  bindsym 9 exec i3-resurrect restore -w 9
+  bindsym 0 exec i3-resurrect restore -w 0
 
   # Back to normal: Enter, Escape, or n
   bindsym Return mode "default"

--- a/i3_resurrect.py
+++ b/i3_resurrect.py
@@ -203,13 +203,12 @@ def restore_layout(workspace, directory):
     layout_file = shlex.quote(
         os.path.join(directory, f'workspace_{workspace}_layout.json'))
     workspace = shlex.quote(workspace)
-    subprocess.Popen(
-        shlex.split(f'i3-msg "workspace --no-auto-back-and-forth {workspace}; '
-                    f'append_layout {layout_file}"'),
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
 
+    i3 = i3ipc.Connection()
+    # Switch to the workspace which we are loading.
+    i3.command(f'workspace --no-auto-back-and-forth {workspace}')
+    # Load the layout into the workspace.
+    i3.command(f'append_layout {layout_file}')
 
 def restore_programs(workspace, directory):
     """

--- a/i3_resurrect.py
+++ b/i3_resurrect.py
@@ -202,13 +202,13 @@ def restore_layout(workspace, directory):
     """
     layout_file = shlex.quote(
         os.path.join(directory, f'workspace_{workspace}_layout.json'))
-    workspace = shlex.quote(workspace)
 
     i3 = i3ipc.Connection()
     # Switch to the workspace which we are loading.
     i3.command(f'workspace --no-auto-back-and-forth {workspace}')
     # Load the layout into the workspace.
     i3.command(f'append_layout {layout_file}')
+
 
 def restore_programs(workspace, directory):
     """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='i3-resurrect',
-    version='1.0.3',
+    version='1.0.4',
     author='Jonathan Haylett',
     author_email='jonathan@haylett.dev',
     py_modules=['i3_resurrect'],


### PR DESCRIPTION
- Switch subprocess i3-msg commands to use python-i3ipc instead
- Fix bug where restoring multi-word workspace names fails due to improper quoting of arguments