### PR TITLE
Add swallow criteria option

### DIFF
--- a/i3_resurrect.py
+++ b/i3_resurrect.py
@@ -50,8 +50,8 @@ def main():
               show_default=True)
 @click.option('--swallow', '-s',
               default='class,instance',
-              help=('The swallow criteria to use.'
-                    'Options: class,instance,title,window_role'),
+              help=('The swallow criteria to use. '
+                    'Options: class, instance, title, window_role'),
               show_default=True)
 def save_workspace(workspace, directory, swallow):
     """

--- a/i3_resurrect.py
+++ b/i3_resurrect.py
@@ -5,27 +5,27 @@ import shlex
 import string
 import subprocess
 import sys
-from json.decoder import JSONDecodeError
 
 import click
 import i3ipc
 import psutil
 from wmctrl import Window
 
-
 TERMINALS = []
 CONFIG = {}
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     global CONFIG
     global TERMINALS
+
     # Load config
     config_file = os.path.expanduser('~/.config/i3-resurrect/config.json')
     try:
         CONFIG = json.loads(open(config_file).read())
-    except JSONDecodeError as e:
+    except json.decoder.JSONDecodeError as e:
         print(f'Error in config file: "{str(e)}"')
         exit(1)
     except PermissionError as e:
@@ -38,16 +38,19 @@ def main():
     # working directory from the window title.
     TERMINALS = ['Gnome-terminal', 'Alacritty']
 
-    pass
-
 
 @main.command('save')
 @click.option('--workspace', '-w', required=True, help='The workspace to save')
 @click.option('--directory', '-d',
               type=click.Path(file_okay=False, writable=True),
               default=os.path.expanduser('~/.i3/i3-resurrect/'),
-              help='The directory to save the workspace to')
-def save_workspace(workspace, directory):
+              help='The directory to save the workspace to',
+              show_default=True)
+@click.option('--swallow', '-s',
+              default='class,instance',
+              help='The swallow criteria to use',
+              show_default=True)
+def save_workspace(workspace, directory, swallow):
     """
     Save an i3 workspace's layout and commands to a file.
     """
@@ -184,7 +187,8 @@ def save_commands(workspace, directory):
 @click.option('--directory', '-d',
               type=click.Path(file_okay=False, writable=True),
               default=os.path.expanduser('~/.i3/i3-resurrect/'),
-              help='The directory to restore the workspace from')
+              help='The directory to restore the workspace from',
+              show_default=True)
 def restore_workspace(workspace, directory):
     """
     Restores an i3 workspace including running programs.

--- a/i3_resurrect.py
+++ b/i3_resurrect.py
@@ -11,6 +11,8 @@ import i3ipc
 import psutil
 from wmctrl import Window
 
+import util
+
 TERMINALS = []
 CONFIG = {}
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -48,7 +50,8 @@ def main():
               show_default=True)
 @click.option('--swallow', '-s',
               default='class,instance',
-              help='The swallow criteria to use',
+              help=('The swallow criteria to use.'
+                    'Options: class,instance,title,window_role'),
               show_default=True)
 def save_workspace(workspace, directory, swallow):
     """
@@ -63,36 +66,41 @@ def save_workspace(workspace, directory, swallow):
                 raise
 
     # Save workspace layout to file.
-    save_layout(workspace, directory)
+    swallow_criteria = swallow.split(',')
+    save_layout(workspace, directory, swallow_criteria)
 
     # Save commands to file.
     save_commands(workspace, directory)
 
 
-def save_layout(workspace, directory):
+def save_layout(workspace, directory, swallow_criteria):
     """
     Saves an i3 workspace layout to a file.
     """
-    # Sanitise inputs properly.
     layout_file = os.path.join(directory, f'workspace_{workspace}_layout.json')
-    workspace = shlex.quote(workspace)
 
-    json_tree = subprocess.getoutput(f'i3-save-tree --workspace {workspace}')
+    i3 = i3ipc.Connection()
 
-    json_lines = iter(json_tree.splitlines())
+    # Get full workspace layout tree from i3.
+    root = json.loads(i3.message(i3ipc.MessageType.GET_TREE, ''))
+    workspace_tree = None
+    for output in root['nodes']:
+        for container in output['nodes']:
+            if container['type'] != 'con':
+                pass
+            for ws in container['nodes']:
+                if ws['name'] == workspace:
+                    workspace_tree = ws
+
     with open(layout_file, 'w') as file:
-        # Strip out the comments that i3-save-tree includes, and remove
-        # unwanted swallow criteria.
-        for line in json_lines:
-            if line.strip().startswith('// '):
-                if 'class' in line:
-                    processed_line = line.replace('// ', '   ', 1)
-                    file.write(f'{processed_line}\n')
-                elif 'instance' in line:
-                    processed_line = line.replace('// ', '   ', 1)[:-1]
-                    file.write(f'{processed_line}\n')
-            else:
-                file.write(f'{line}\n')
+        # Build new workspace tree suitable for restoring and write it to a
+        # file.
+        file.write(
+            json.dumps(
+                util.build_tree(workspace_tree, swallow_criteria),
+                indent=2,
+            )
+        )
 
 
 def save_commands(workspace, directory):

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setup(
     name='i3-resurrect',
-    version='1.0.4',
+    version='1.0.5-2',
     author='Jonathan Haylett',
     author_email='jonathan@haylett.dev',
-    py_modules=['i3_resurrect'],
+    py_modules=['i3_resurrect', 'util'],
     url='https://github.com/JonnyHaystack/i3-resurrect',
     license='GNU GPL Version 3',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='i3-resurrect',
-    version='1.0.5-2',
+    version='1.1.0',
     author='Jonathan Haylett',
     author_email='jonathan@haylett.dev',
     py_modules=['i3_resurrect', 'util'],

--- a/util.py
+++ b/util.py
@@ -1,0 +1,57 @@
+import re
+
+
+def build_tree(con, swallow_criteria):
+    """
+    Recursive function to build a restorable window layout tree using basic
+    Python data structures.
+    """
+    tree = []
+
+    nodes = con['nodes']
+
+    # Base case.
+    if nodes == []:
+        return tree
+
+    # Step case.
+    for node in nodes:
+        container = {}
+        attributes = [
+            'border',
+            'current_border_width',
+            'floating',
+            'focused',
+            'fullscreen_mode',
+            'geometry',
+            'last_split_layout',
+            'layout',
+            'name',
+            'orientation',
+            'percent',
+            'scratchpad_state',
+            'sticky',
+            'type',
+            'workspace_layout',
+        ]
+
+        # Set attributes.
+        for attribute in attributes:
+            if attribute in node:
+                container[attribute] = node[attribute]
+
+        # Set swallow criteria.
+        if 'window_properties' in node:
+            container['swallows'] = [{}]
+            for criterion in swallow_criteria:
+                if criterion in node['window_properties']:
+                    # Escape special characters in swallow criteria.
+                    escaped = re.escape(node['window_properties'][criterion])
+                    # Regex formatting.
+                    value = f'^{escaped}$'
+                    container['swallows'][0][criterion] = value
+        container['nodes'] = build_tree(node, swallow_criteria)
+
+        tree.append(container)
+
+    return tree


### PR DESCRIPTION
- Add `--swallow` option which allows the user to specify swallow criteria
- Stop using i3-save-tree and instead build workspace tree manually using i3ipc