### PR TITLE
Fix multi arg commands

### DIFF
--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -119,7 +119,11 @@ def restore(workspace, directory, profile):
 
         # Execute command via i3 exec.
         i3 = i3ipc.Connection()
-        i3.command(f'exec cd "{working_directory}" && {command}')
+        reply = i3.command(f'exec cd "{working_directory}" && {command}')
+        if not reply[0].success:
+            error_msg = reply[0].error
+            util.eprint('i3 failed to execute command: {command}. '
+                        f'It returned the following error message: {error_msg}')
 
 
 def windows_in_workspace(workspace):

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -112,7 +112,7 @@ def restore(workspace, directory, profile):
         if isinstance(cmdline, list):
             # Quote each argument of the command in case some of them contain
             # spaces.
-            cmdline = [f'"{arg}"' for arg in cmdline if arg != '']
+            cmdline = [f'{arg}' for arg in cmdline if arg != '']
             command = ' '.join(cmdline)
         else:
             command = cmdline

--- a/tests/test_data/test_profile_programs.json
+++ b/tests/test_data/test_profile_programs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "command": [
+      "xterm"
+    ],
+    "working_directory": "/tmp"
+  },
+  {
+    "command": [
+      "xterm"
+    ],
+    "working_directory": "/tmp"
+  },
+  {
+    "command": [
+      "xterm"
+    ],
+    "working_directory": "/tmp"
+  }
+]

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -53,3 +53,13 @@ def test_get_window_command(monkeypatch):
         'title': 'Some arbitrary title',
     }
     assert programs.get_window_command(program3, ['program3']) == []
+
+
+def test_restore():
+    workspace = "1"
+    directory = "tests/test_data"
+    profile = "test_profile"
+
+    programs.restore(workspace, directory, profile)
+
+    # TODO Assert programs in profile are on workspace


### PR DESCRIPTION
Thanks for making this project! I've been playing around with this for a bit, and it seems to work great, although I ran into a small issue.
When custom commands with multiple arguments are defined in `*_programs.json`, they don't get executed. For example:
```json
[
  {
    "command": [
      "alacritty -d 0 0 -e '.config/i3/finances/vim-beancount.sh' &"
    ],
    "working_directory": "/home/nicole"
  },
  {
    "command": [
      "firejail --overlay-tmpfs --ignore=apparmor firefox --no-remote"
    ],
    "working_directory": "/home/nicole"
  },
  {
    "command": [
      "alacritty"
    ],
    "working_directory": "/home/nicole"
  }
]
```
With the above settings only the last command is executed, the rest silently fails without any errors.

This tiny PR fixes that by removing quotes in the `cmdline` parsing. The commands are run as expected now.
It also adds an extra check on the reponse i3 gives back. This could probably be more elegant, but it is helpful in debugging when creating custom commands.