### PR TITLE
Ensure programs that modify their own cmdline have args split correctly

### DIFF
--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -51,8 +51,8 @@ def save(workspace, numeric, directory, profile):
         if command in ([], ''):
             continue
 
-        # Remove empty string arguments from command.
-        command = [arg for arg in command if arg != '']
+        # Ensure args are split properly and remove empty args.
+        command = split_args(command)
 
         try:
             # Obtain working directory using psutil.
@@ -110,9 +110,11 @@ def restore(workspace, directory, profile):
         # If cmdline is array, join it into one string for use with i3's exec
         # command.
         if isinstance(cmdline, list):
+            # Ensure args are split properly and remove empty args.
+            cmdline = split_args(cmdline)
             # Quote each argument of the command in case some of them contain
             # spaces.
-            cmdline = [f'"{arg}"' for arg in cmdline if arg != '']
+            cmdline = [f'"{arg}"' for arg in cmdline]
             command = ' '.join(cmdline)
         else:
             command = cmdline
@@ -120,6 +122,25 @@ def restore(workspace, directory, profile):
         # Execute command via i3 exec.
         i3 = i3ipc.Connection()
         i3.command(f'exec cd "{working_directory}" && {command}')
+
+
+def split_args(cmdline):
+    """
+    Function for making sure command line arguments are split properly and
+    removing empty arguments.
+
+    Args:
+        cmdline: The cmdline to process.
+    """
+    # Sometimes the process may modify its own cmdline which can result in the
+    # cmdline returned by psutil not being split correctly, so we must make
+    # sure every element is a single argument.
+    result = []
+    for arg in cmdline:
+        result += shlex.split(arg)
+    # Empty string args cause problems with i3 exec so we filter them out.
+    result = [arg for arg in result if arg != '']
+    return result
 
 
 def windows_in_workspace(workspace, numeric):

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -2,6 +2,29 @@ from i3_resurrect import config
 from i3_resurrect import programs
 
 
+def test_split_args():
+    cmdline = [
+        'test --test "test1 test2 test3" -test -t -e -s -t test',
+        'test',
+        '',
+        'test4',
+    ]
+    expected_cmdline = [
+        'test',
+        '--test',
+        'test1 test2 test3',
+        '-test',
+        '-t',
+        '-e',
+        '-s',
+        '-t',
+        'test',
+        'test',
+        'test4',
+    ]
+    assert programs.split_args(cmdline) == expected_cmdline
+
+
 def test_get_window_command(monkeypatch):
     # Monkeypatch config.
     monkeypatch.setattr(


### PR DESCRIPTION
Sometimes processes rewrite their own cmdline which often means the args
are no longer separated by the NUL character, which causes issues when
running the command. This commit ensures every element of the cmdline
array is an atomic argument, so that programs that modify their own
cmdline will be restored correctly.