### PR TITLE
Bugfix/filename detox fix #54

### DIFF
--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -15,7 +15,8 @@ def save(workspace, numeric, directory, profile, swallow_criteria):
     """
     Save an i3 workspace layout to a file.
     """
-    filename = f'workspace_{workspace}_layout.json'
+    workspace_id = util.filename_filter(workspace)
+    filename = f'workspace_{workspace_id}_layout.json'
     if profile is not None:
         filename = f'{profile}_layout.json'
     layout_file = Path(directory) / filename
@@ -37,7 +38,8 @@ def read(workspace, directory, profile):
     """
     Read saved layout file.
     """
-    filename = f'workspace_{workspace}_layout.json'
+    workspace_id = util.filename_filter(workspace)
+    filename = f'workspace_{workspace_id}_layout.json'
     if profile is not None:
         filename = f'{profile}_layout.json'
     layout_file = Path(directory) / filename

--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -190,8 +190,9 @@ def remove(workspace, directory, profile, target):
         programs_filename = f'{profile}_programs.json'
         layout_filename = f'{profile}_layout.json'
     elif workspace is not None:
-        programs_filename = f'workspace_{workspace}_programs.json'
-        layout_filename = f'workspace_{workspace}_layout.json'
+        workspace_id = util.filename_filter(workspace)
+        programs_filename = f'workspace_{workspace_id}_programs.json'
+        layout_filename = f'workspace_{workspace_id}_layout.json'
     else:
         util.eprint('Either --profile or --workspace must be specified.')
         sys.exit(1)

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -17,7 +17,8 @@ def save(workspace, numeric, directory, profile):
     Save the commands to launch the programs open in the specified workspace
     to a file.
     """
-    filename = f'workspace_{workspace}_programs.json'
+    workspace_id = util.filename_filter(workspace)
+    filename = f'workspace_{workspace_id}_programs.json'
     if profile is not None:
         filename = f'{profile}_programs.json'
     programs_file = Path(directory) / filename
@@ -80,7 +81,8 @@ def restore(workspace, directory, profile):
     """
     Restore the running programs from an i3 workspace.
     """
-    filename = f'workspace_{workspace}_programs.json'
+    workspace_id = util.filename_filter(workspace)
+    filename = f'workspace_{workspace_id}_programs.json'
     if profile is not None:
         filename = f'{profile}_programs.json'
     programs_file = Path(directory) / filename

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -1,8 +1,22 @@
 import sys
 
-
 def eprint(*args, **kwargs):
     """
     Function for printing to stderr.
     """
     print(*args, file=sys.stderr, **kwargs)
+
+
+def filename_filter(filename):
+    """
+    Take a string and return a valid filename constructed from the string.
+"""
+    blacklist = '/\:*"<>|'
+    if filename is None:
+        return filename
+
+    # remove blacklisted chars.
+    for char in blacklist:
+        filename = filename.replace(char, '')
+
+    return filename


### PR DESCRIPTION
Attempt to fix read/write issues for title containing  ''/'    other character as '\:*"<>|' are also removed since they aren't allowed with other operating system such as Windows.
A function filename_filter is created in order to remove theses characters prior to save the file.
It is called also for restoration in order to catch the corresponding file with filtered name.
There is one drawback : for example titles as 1:www and 1www cause conflict.
Is not a very big deal for me as maybe nobody do this kind of think. It is also possible to replace theses char by other, but make filename less readable.