### PR TITLE
Restore only missing programs

### DIFF
--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -43,6 +43,7 @@ def read(workspace, directory, profile):
     if profile is not None:
         filename = f'{profile}_layout.json'
     layout_file = Path(directory) / filename
+
     layout = None
     try:
         layout = json.loads(layout_file.read_text())

--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -118,7 +118,8 @@ def restore_workspace(workspace, numeric, directory, profile, target):
 
     if target != 'layout_only':
         # Restore programs.
-        programs.restore(workspace, directory, profile)
+        saved_programs = programs.read(workspace, directory, profile)
+        programs.restore(workspace_name, saved_programs)
 
 
 @main.command('ls')


### PR DESCRIPTION
Previously, when restoring programs, all of the saved programs would be launched regardless of what is already running in that workspace. This PR alters this behaviour such that only programs that are not already open in the workspace will be restored.