### PR TITLE
Split single argument commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A simple but flexible solution to saving and restoring i3 workspaces
    * [Window command mappings](#window-command-mappings)
    * [Terminals](#terminals)
    * [Per window swallow criteria](#per-window-swallow-criteria)
+* [Troubleshooting](#troubleshooting)
 * [Contributing](#contributing)
 * [Contributors](#contributors)
 * [License](#license)
@@ -470,6 +471,36 @@ This can be achieved by putting the following in your config file:
   ...
 }
 ```
+
+## Troubleshooting
+
+### Programs with spaces in the executable path
+
+If the process of a program you are saving has one only argument (the
+executable) and the executable path contains spaces, it cannot be saved/restored 
+correctly unless you [create a custom command mapping](#window-command-mappings)
+for it.
+
+See issue #55 for why this is the case.
+
+### Manually editing programs files
+
+If you manually edit a saved programs file, you must be aware of a few things:
+
+If using an array to specify the command, each array element must be a distinct
+argument, otherwise it won't work. For example:
+```
+"command": ["some-program arg1 arg2"]
+```
+is invalid, but both
+```
+"command": ["some-program", "arg1", "arg2"]
+```
+and
+```
+"command": "some-program arg1 arg2"
+```
+are valid.
 
 ## Contributing
 

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -192,6 +192,14 @@ def get_window_command(window_properties, cmdline):
     highest score is then returned.
     """
     window_command_mappings = config.get('window_command_mappings', [])
+
+    # If cmdline has only one argument, try to split it. This means we can
+    # cover cases where the process overwrote its own cmdline, with the
+    # tradeoff that legitimate single argument cmdlines with spaces in the
+    # executable path will be broken.
+    if len(cmdline) == 1:
+        cmdline = shlex.split(cmdline[0])
+
     command = cmdline
 
     # If window command mappings is a dictionary in the config file, use the
@@ -251,7 +259,8 @@ def calc_rule_match_score(rule, window_properties):
     for criterion in criteria:
         if criterion in rule:
             # Score is zero if there are any non-matching criteria.
-            if rule[criterion] != window_properties[criterion]:
+            if (criterion not in window_properties
+                    or rule[criterion] != window_properties[criterion]):
                 return 0
             score += criteria[criterion]
     return score

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -23,6 +23,14 @@ def test_get_window_command(monkeypatch):
                 {
                     'class': 'Program4',
                     'command': 'run_program4 {1}'
+                },
+                {
+                    'class': 'Program6',
+                    'command': 'chrome {1}'
+                },
+                {
+                    'class': 'Program7',
+                    'command': ['/opt/Pulse SMS/pulse-sms'],
                 }
             ],
         },
@@ -49,7 +57,8 @@ def test_get_window_command(monkeypatch):
         'class': 'Program2',
         'title': 'Main window title',
     }
-    assert programs.get_window_command(program2_main, ['program2']) == ['program2']
+    assert programs.get_window_command(
+        program2_main, ['program2']) == ['program2']
 
     # Test that title only mapping matches any window with matching title.
     program3 = {
@@ -67,3 +76,42 @@ def test_get_window_command(monkeypatch):
         program4,
         ['/opt/Program4/program4', '/tmp/test.txt'],
     ) == ['run_program4', '/tmp/test.txt']
+
+    # Test splitting of single arg command.
+    program5 = {
+        'class': 'Program5',
+        'title': 'program 5 title',
+    }
+    assert programs.get_window_command(
+        program5,
+        ['/opt/google/chrome/chrome --profile-directory=Default '
+         '--app=http://instacalc.com --user-data-dir=.config'],
+    ) == [
+        '/opt/google/chrome/chrome',
+        '--profile-directory=Default',
+        '--app=http://instacalc.com',
+        '--user-data-dir=.config',
+    ]
+
+    # Test splitting of single arg command when used with mapping and cmdline
+    # interpolation.
+    program6 = {
+        'class': 'Program6',
+    }
+    assert programs.get_window_command(
+        program6,
+        ['/opt/google/chrome/chrome --profile-directory=Default '
+         '--app=http://instacalc.com --user-data-dir=.config'],
+    ) == [
+        'chrome',
+        '--profile-directory=Default',
+    ]
+
+    # Test single arg command with space in executable path.
+    program7 = {
+        'class': 'Program7',
+    }
+    assert programs.get_window_command(
+        program7,
+        ['/opt/Pulse SMS/pulse-sms']
+    ) == ['/opt/Pulse SMS/pulse-sms']


### PR DESCRIPTION
Some processes modify their own cmdline so that everything is stuck in
the first argument in shell command form. This is impossible to detect,
but it can be worked around by using shlex.split() on the first argument
if the cmdline has only one argument. The drawback of this is that
valid single arg commands with spaces in the executable path will not
work unless a command mapping is created for them in the config file.

Closes #55 