### PR TITLE
Fix crash when restoring programs

### DIFF
--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -70,7 +70,8 @@ def restore(workspace_name, saved_programs):
     # Remove already running programs from the list of program to restore.
     running_programs = get_programs(workspace_name, False)
     for program in running_programs:
-        saved_programs.remove(program)
+        if program in saved_programs:
+            saved_programs.remove(program)
 
     i3 = i3ipc.Connection()
     for entry in saved_programs:


### PR DESCRIPTION
There was a crash when restoring programs thrown by list.remove() because
I was not checking if a program was in the saved programs list before
removing it.