### PR TITLE
Fixed bug when cmdline contains empty args

### DIFF
--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -205,12 +205,15 @@ def get_window_command(window_properties, cmdline, exe):
     """
     window_command_mappings = config.get('window_command_mappings', [])
 
+    # Remove empty args from cmdline.
+    cmdline = [arg for arg in cmdline if arg != '']
+
+    # If cmdline has only one argument which is not a known executable path,
+    # try to split it. This means we can cover cases where the process
+    # overwrote its own cmdline, with the tradeoff that legitimate single
+    # argument cmdlines with a relative executable path containing spaces will
+    # be broken.
     if len(cmdline) == 1 and shutil.which(cmdline[0]) is None:
-        # If cmdline has only one argument which is not a known executable
-        # path, try to split it. This means we can cover cases where the
-        # process overwrote its own cmdline, with the tradeoff that legitimate
-        # single argument cmdlines with a relative executable path containing
-        # spaces will be broken.
         cmdline = shlex.split(cmdline[0])
     # Use the absolute executable path in case a relative path was used.
     if exe is not None:

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -143,4 +143,17 @@ def test_get_window_command(monkeypatch):
         program8,
         ['/opt/Pulse SMS/pulse-sms'],
         '/opt/Pulse SMS/pulse-sms',
-    )
+    ) == ['/opt/Pulse SMS/pulse-sms', 'SMS/pulse-sms']
+
+    # Test cmdline with empty args is processed correctly.
+    assert programs.get_window_command(
+        program5,
+        ['/opt/google/chrome/chrome --profile-directory=Default '
+         '--app=http://instacalc.com --user-data-dir=.config', '', '', '', ''],
+        '/opt/google/chrome/chrome',
+    ) == [
+        '/opt/google/chrome/chrome',
+        '--profile-directory=Default',
+        '--app=http://instacalc.com',
+        '--user-data-dir=.config',
+    ]


### PR DESCRIPTION
When a process cmdline contains multiple null bytes in a row, psutil
splits it such that you have some empty arguments. This meant that
i3-resurrect would assume it was a multi-argument command, and would not
split cmdline[0]. I have fixed this by removing all empty arguments from
the cmdline at the beginning of get_window_command().