### PR TITLE
Add quotes around workspace name when switching

### DIFF
--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -110,7 +110,7 @@ def restore_workspace(workspace, numeric, directory, profile, target):
         workspace_name = workspace
 
     # Switch to the workspace which we are loading.
-    i3.command(f'workspace --no-auto-back-and-forth {workspace_name}')
+    i3.command(f'workspace --no-auto-back-and-forth "{workspace_name}"')
 
     if target != 'programs_only':
         # Load workspace layout.


### PR DESCRIPTION
Workspace name must be quoted when switching to that workspace otherwise
it fails to switch if the workspace name begins with whitespace.

Fixes #75 