### PR TITLE
Modified argument parsing to mitigate problems when arguments contain quotes.

### DIFF
--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -87,9 +87,11 @@ def restore(workspace_name, saved_programs):
         # If cmdline is array, join it into one string for use with i3's exec
         # command.
         if isinstance(cmdline, list):
-            # Quote each argument of the command in case some of them contain
-            # spaces.
-            cmdline = [f'\\"{arg}\\"' for arg in cmdline if arg != '']
+            # Quote each argument of the command in case some of
+            # them contain spaces. Also protect quotes contained in the
+            # arguments and those to be added from i3's command parser.
+            cmdline = ['\\"' + arg.replace('"', '\\\\\\"') + '\\"' \
+                    for arg in cmdline if arg != '']
             command = ' '.join(cmdline)
         else:
             command = cmdline


### PR DESCRIPTION
When the arguments of saved programs contain double quotes, for instance `termite --exec='ranger --cmd="set show_hidden=false"'`,  the current parsing method doesn't work.
The following commit solves this issue (refer [i3-userguide-exec_quoting](https://i3wm.org/docs/userguide.html#exec_quoting)).