### PR TITLE
Allow saving whole session with all workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,59 +133,87 @@ pip3 install --user .
 
 Full command line documentation:
 ```
-Usage: i3-resurrect save [OPTIONS]
 
-  Save an i3 workspace's layout and running programs to a file.
+Usage: i3-resurrect save [OPTIONS] [WORKSPACES]...
+
+  Save i3 workspace(s) layout(s) or whole session and running programs to a file.
+
+  Use cases:
+
+  i3-resurrect save [--session]
+
+  i3-resurrect save [--workspace] WORKSPACES
+
+  WORKSPACES are the workspace(s) to save. [default: current workspace]
 
 Options:
-  -w, --workspace TEXT       The workspace to save.
-                             [default: current workspace]
+  -w, --workspace            Save workspace(s).
   -n, --numeric              Select workspace by number instead of name.
-  -d, --directory DIRECTORY  The directory to save the workspace to.
-                             [default: ~/.i3/i3-resurrect]
-  -p, --profile TEXT         The profile to save the workspace to.
-  -s, --swallow TEXT         The swallow criteria to use.
-                             [options: class,instance,title,window_role]
+  -S, --session              Save current session.
+  -d, --directory DIRECTORY  The directory to save the workspace to. [default: ~/.i3/i3-resurrect]
+  -p, --profile TEXT         The profile to save.
+  -s, --swallow TEXT         The swallow criteria to use. [options: class,instance,title,window_role]
                              [default: class,instance]
   --layout-only              Only save layout.
   --programs-only            Only save running programs.
+  -h, --help                 Show this message and exit.
 
 
-Usage: i3-resurrect restore [OPTIONS]
+Usage: i3-resurrect restore [OPTIONS] [WORKSPACES]...
 
-  Restore i3 workspace layout and programs.
+  Restore i3 workspace(s) layout(s) or whole session and programs.
+
+  Use cases:
+
+  i3-resurrect restore [--session]
+
+  i3-resurrect restore [--workspace] WORKSPACES
+
+  i3-resurrect restore WORKSPACE_LAYOUT TARGET_WORKSPACE
+
+  WORKSPACES are the workspace(s) to restore. [default: current workspace]
+
+  WORKSPACE_LAYOUT is the workspace file to load. TARGET_WORKSPACE is the target workspace [default:
+  current workspace]
 
 Options:
-  -w, --workspace TEXT       The workspace to restore.
-                             [default: current workspace]
-  -n, --numeric              Select workspace by number instead of name.
-  -d, --directory DIRECTORY  The directory to restore the workspace from.
-                             [default: ~/.i3/i3-resurrect]
-  -p, --profile TEXT         The profile to restore the workspace from.
+  -w, --workspace            Restore workspace(s).
+  -n, --numeric              Select workspace(s) by number instead of name.
+  -S, --session              Restore current session.
+  -d, --directory DIRECTORY  The directory to restore the workspace from. [default: ~/.i3/i3-resurrect]
+  -p, --profile TEXT         The profile to restore.
   --layout-only              Only restore layout.
   --programs-only            Only restore running programs.
+  -c, --clean                Move program that are not part of the workspace layout to               the
+                             scratchpad.
+  -r, --reload               Move program from the workspace to the scratchpad. before restore it.
+  -K, --kill                 Kill unwanted program insted of moving it the scratchpad.
+  -h, --help                 Show this message and exit.
 
 
-Usage: i3-resurrect ls [OPTIONS] [[workspaces|profiles]]
+Usage: i3-resurrect rm [OPTIONS] [WORKSPACES]...
 
-  List saved workspaces or profiles.
-
-Options:
-  -d, --directory DIRECTORY  The directory to search in.
-                             [default: ~/.i3/i3-resurrect]
-
-
-Usage: i3-resurrect rm [OPTIONS]
-
-  Remove saved layout or programs.
+  Remove saved worspace(s) layout(s), whole session, or programs.
 
 Options:
-  -w, --workspace TEXT       The saved workspace to delete.
-  -d, --directory DIRECTORY  The directory to delete from.
-                             [default: ~/.i3/i3-resurrect]
+  -w, --workspace            Delete workspace(s) files.
+  -S, --session              Delete saved session layout.
+  -d, --directory DIRECTORY  The directory to delete from. [default: ~/.i3/i3-resurrect]
   -p, --profile TEXT         The profile to delete.
   --layout-only              Only delete saved layout.
   --programs-only            Only delete saved programs.
+  -h, --help                 Show this message and exit.
+
+
+Usage: i3-resurrect kill [OPTIONS] [WORKSPACES]...
+
+  Kill workspace(s) or whole session.
+
+Options:
+  -w, --workspace  Kill workspace(s) layout(s) and program(s).
+  -S, --session    Kill all workspace(s) and program(s) in current session.
+  -F, --force      Do not ask for confirmation.
+  -h, --help       Show this message and exit.
 ```
 
 Basic usage, matching only window class/instance:

--- a/i3_resurrect/config.py
+++ b/i3_resurrect/config.py
@@ -23,6 +23,9 @@ def create_default():
         ],
         'window_swallow_criteria': {},
         'terminals': ['Gnome-terminal', 'Alacritty'],
+        'map_timeout': 0,
+        'exec_timeout': 0,
+        'restore_timeout': 2,
     }
 
     # Make config directory if it doesn't exist.

--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -46,7 +46,6 @@ def read(workspace, directory):
     except FileNotFoundError:
         util.eprint('Could not find saved layout for workspace '
                         f'"{workspace}"')
-        sys.exit(1)
     return layout
 
 

--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -11,14 +11,12 @@ from . import treeutils
 from . import util
 
 
-def save(workspace, numeric, directory, profile, swallow_criteria):
+def save(workspace, numeric, directory, swallow_criteria):
     """
     Save an i3 workspace layout to a file.
     """
     workspace_id = util.filename_filter(workspace)
     filename = f'workspace_{workspace_id}_layout.json'
-    if profile is not None:
-        filename = f'{profile}_layout.json'
     layout_file = Path(directory) / filename
 
     workspace_tree = treeutils.get_workspace_tree(workspace, numeric)
@@ -34,24 +32,19 @@ def save(workspace, numeric, directory, profile, swallow_criteria):
         )
 
 
-def read(workspace, directory, profile):
+def read(workspace, directory):
     """
     Read saved layout file.
     """
     workspace_id = util.filename_filter(workspace)
     filename = f'workspace_{workspace_id}_layout.json'
-    if profile is not None:
-        filename = f'{profile}_layout.json'
     layout_file = Path(directory) / filename
 
     layout = None
     try:
         layout = json.loads(layout_file.read_text())
     except FileNotFoundError:
-        if profile is not None:
-            util.eprint(f'Could not find saved layout for profile "{profile}"')
-        else:
-            util.eprint('Could not find saved layout for workspace '
+        util.eprint('Could not find saved layout for workspace '
                         f'"{workspace}"')
         sys.exit(1)
     return layout

--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -11,6 +11,18 @@ from . import treeutils
 from . import util
 
 
+def list(i3, numeric):
+    # List all active workspaces
+    workspaces_data = i3.get_workspaces()
+    workspaces = []
+    for n, workspace_data in enumerate(workspaces_data):
+        # Get all active workspaces from session
+        if numeric:
+            workspaces.append(str(workspace_data.num))
+        else:
+            workspaces.append(workspace_data.name)
+    return workspaces
+
 def save(workspace, numeric, directory, swallow_criteria):
     """
     Save an i3 workspace layout to a file.

--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -2,11 +2,13 @@ import json
 import shlex
 import subprocess
 import sys
+from time import sleep
 import tempfile
 from pathlib import Path
 
 import i3ipc
 
+from . import config
 from . import programs
 from . import treeutils
 from . import util
@@ -185,6 +187,8 @@ def restore(workspace_name, layout, saved_programs, target, kill=False):
         # user to lose their windows no matter what.
         for window in preserved_windows:
             xdo_map_window(window['window'])
+            map_timeout = config.get('map_timeout', 0)
+            sleep(map_timeout)
 
 
 def build_layout(tree, swallow):

--- a/i3_resurrect/layout.py
+++ b/i3_resurrect/layout.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import i3ipc
 
+from . import programs
 from . import treeutils
 from . import util
 
@@ -61,36 +62,89 @@ def read(workspace, directory):
     return layout
 
 
-def restore(workspace_name, layout):
+def remove_windows_from_workspace(normal_windows, kill=False):
+    for window in normal_windows:
+        #  window and program instance that don't match to saved list have to be killed
+        if kill:
+            xdo_kill_window(window['window'])
+        else:
+            xdo_map_window(window['window'])
+            xdo_focus_window(window['window'])
+            i3.command(f'move scratchpad') 
+
+
+def clean_workspace(layout, saved_programs, normal_windows, target, kill=False):
+    """"
+    Move windows that don't match saved programs in layout to scatchpad or kill it.
+    """
+    i3 = i3ipc.Connection()
+    preserved_windows = []
+    saved_windows = treeutils.get_leaves(layout)
+    for saved_program in saved_programs:
+        current_score = 0
+        best_match = None
+        # Get swallow criterias of saved program to restore
+        rule = saved_program['window_properties']
+
+        for window in normal_windows:
+            window_properties = window['window_properties']
+            if rule['class'] == window_properties['class']:
+                # The window is part of the saved layout
+                # calculate match score of window
+                score = programs.calc_rule_match_score(rule, window_properties)
+                if score > current_score:
+                    current_score = score
+                    # Bestmatched window
+                    best_match = window
+
+        if current_score != 0:
+            # saved window already open
+            preserved_windows.append(best_match)
+            normal_windows.remove(best_match)
+
+    remove_windows_from_workspace(normal_windows, target)
+
+    return preserved_windows
+
+
+def restore(workspace_name, layout, saved_programs, target, kill=False):
     """
     Restore an i3 workspace layout.
     """
-    if layout == {}:
-        return
-    window_ids = []
-    placeholder_window_ids = []
+    normal_windows = []
+    placeholder_windows = []
 
     # Get ids of all placeholder or normal windows in workspace.
     ws = treeutils.get_workspace_tree(workspace_name, False)
     windows = treeutils.get_leaves(ws)
-    for con in windows:
-        window_id = con['window']
-        if is_placeholder(con):
+
+    for window in windows:
+        if is_placeholder(window):
             # If window is a placeholder, add it to list of placeholder
             # windows.
-            placeholder_window_ids.append(window_id)
+            placeholder_windows.append(window)
         else:
             # Otherwise, add it to the list of regular windows.
-            window_ids.append(window_id)
+            normal_windows.append(window)
 
-    # Unmap all non-placeholder windows in workspace.
-    for window_id in window_ids:
-        xdo_unmap_window(window_id)
+    if target == 'clean':
+        preserved_windows = clean_workspace(layout, saved_programs, normal_windows, target, kill)
+    elif target == 'reload':
+        remove_windows_from_workspace(normal_windows, target, kill)
+    else:
+        preserved_windows = normal_windows
 
     # Remove any remaining placeholder windows in workspace so that we don't
     # have duplicates.
-    for window_id in placeholder_window_ids:
-        xdo_kill_window(window_id)
+    for window in placeholder_windows:
+        xdo_kill_window(window['window'])
+
+    if layout == {}:
+        return
+
+    # Unmap all non-placeholder windows in workspace.
+    for window in preserved_windows:
+        xdo_unmap_window(window['window'])
 
     try:
         i3 = i3ipc.Connection()
@@ -129,8 +183,8 @@ def restore(workspace_name, layout):
     finally:
         # Map all unmapped windows. We use finally because we don't want the
         # user to lose their windows no matter what.
-        for window_id in window_ids:
-            xdo_map_window(window_id)
+        for window in preserved_windows:
+            xdo_map_window(window['window'])
 
 
 def build_layout(tree, swallow):

--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+from time import sleep
 from pathlib import Path
 
 import click
@@ -178,6 +179,9 @@ def restore_workspaces(workspace, numeric, session, directory, profile, target,
     """
     i3 = i3ipc.Connection()
 
+    # Display warning message
+    nag_bar = util.nag_bar_process()
+
     focused_workspace = i3.get_tree().find_focused().workspace().name
 
     if not workspaces:
@@ -239,6 +243,10 @@ def restore_workspaces(workspace, numeric, session, directory, profile, target,
             if target != 'layout_only':
                 # Restore programs.
                 programs.restore(target_workspace, saved_programs)
+
+    restore_timeout = config.get('restore_timeout', 2)
+    sleep(restore_timeout)
+    nag_bar.terminate()
 
 
 @main.command('ls')
@@ -369,7 +377,6 @@ def kill(workspace, session, force, workspaces):
             answer = input("Kill all workspaces in current session y/N ? ")
     elif workspace:
         if not force:
-            import ipdb; ipdb.set_trace()
             w_list = workspaces[0]
             for workspace in workspaces[1:]:
                 w_list = w_list + "," + "'" + workspace + "'"

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -13,15 +13,13 @@ from . import treeutils
 from . import util
 
 
-def save(workspace, numeric, directory, profile):
+def save(workspace, numeric, directory):
     """
     Save the commands to launch the programs open in the specified workspace
     to a file.
     """
     workspace_id = util.filename_filter(workspace)
     filename = f'workspace_{workspace_id}_programs.json'
-    if profile is not None:
-        filename = f'{profile}_programs.json'
     programs_file = Path(directory) / filename
 
     # Print deprecation warning if using old dictionary method of writing
@@ -40,25 +38,19 @@ def save(workspace, numeric, directory, profile):
         f.write(json.dumps(programs, indent=2))
 
 
-def read(workspace, directory, profile):
+def read(workspace, directory):
     """
     Read saved programs file.
     """
     workspace_id = util.filename_filter(workspace)
     filename = f'workspace_{workspace_id}_programs.json'
-    if profile is not None:
-        filename = f'{profile}_programs.json'
     programs_file = Path(directory) / filename
 
     programs = None
     try:
         programs = json.loads(programs_file.read_text())
     except FileNotFoundError:
-        if profile is not None:
-            util.eprint('Could not find saved programs for profile '
-                        f'"{profile}"')
-        else:
-            util.eprint('Could not find saved programs for workspace '
+        util.eprint('Could not find saved programs for workspace '
                         f'"{workspace}"')
         sys.exit(1)
     return programs

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -3,6 +3,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+from time import sleep
 from pathlib import Path
 
 import i3ipc
@@ -93,6 +94,8 @@ def restore(workspace_name, saved_programs):
 
         # Execute command via i3 exec.
         i3.command(f'exec "cd \\"{working_directory}\\" && {command}"')
+        exec_timeout = config.get('exec_timeout', 0.1)
+        sleep(exec_timeout)
 
 
 def get_programs(workspace, numeric):

--- a/i3_resurrect/programs.py
+++ b/i3_resurrect/programs.py
@@ -147,6 +147,7 @@ def get_programs(workspace, numeric):
 
         # Add the command to the list.
         programs.append({
+            'window_properties': con['window_properties'],
             'command': command,
             'working_directory': working_directory
         })

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import subprocess
 from os.path import expandvars
 from pathlib import Path
 
@@ -47,3 +48,7 @@ def list_filenames(directory):
         programs_file = Path(directory) / programs_filenames[n]
         files.append((layout_file, programs_file))
     return files
+
+
+def nag_bar_process():
+    return subprocess.Popen(["i3-nagbar", "--type", "warning", "-m", "Currently restoring session. Don't change workspace focus!"])

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -1,3 +1,5 @@
+import os
+import re
 import sys
 from os.path import expandvars
 from pathlib import Path
@@ -30,3 +32,18 @@ def resolve_directory(directory, profile=None):
     if profile is not None:
         directory = directory / profile
     return directory
+
+
+def list_filenames(directory):
+    (_, _, filenames) = next(os.walk(directory))
+    layout_regex = re.compile(r'.*_layout.json')
+    layout_filenames = list(filter(layout_regex.search, filenames))
+    programs_regex = re.compile(r'.*_programs.json')
+    programs_filenames = list(filter(programs_regex.search, filenames))
+    # Create a list of tuples to save workspace files
+    files = []
+    for n, layout_filename in enumerate(layout_filenames):
+        layout_file = Path(directory) / layout_filename
+        programs_file = Path(directory) / programs_filenames[n]
+        files.append((layout_file, programs_file))
+    return files

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -28,5 +28,5 @@ def filename_filter(filename):
 def resolve_directory(directory, profile=None):
     directory = Path(expandvars(directory)).expanduser()
     if profile is not None:
-        directory = directory / 'profiles'
+        directory = directory / profile
     return directory


### PR DESCRIPTION
Work in progress

Made a pull request for this feature:
- i3-resurrect save/restore --session to save whole session
- i3-resurrect save/restore --workspace list-of-workspaces for saving multiples workspaces
- i3-resurrect restore --session --clear for deleting active workspaces before restoring.

This implementation use subdir for saving profiles instead of files, to allow saving multiples workspaces or whole session profile

this may be usefull for some people