### PR TITLE
Add error handling for missing directory

### DIFF
--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -138,6 +138,10 @@ def list_workspaces(directory, item):
     """
     directory = util.resolve_directory(directory)
 
+    if not path.isdir(directory):
+        print(f'Directory {directory} not found')
+        return
+    
     if item == 'workspaces':
         workspaces = []
         for entry in directory.iterdir():


### PR DESCRIPTION
Hi team,

I've made some changes to the code to add error handling for when the specified directory is not found. Previously, the code would simply crash with a traceback if the directory didn't exist, which can be confusing and unhelpful for the user.

With my changes, the code now checks if the directory exists before proceeding, and if it doesn't, a new error message is displayed indicating that the directory couldn't be found. This should make it easier for the user to identify and fix the issue.

Let me know if you have any feedback or suggestions for further improvements.

Thanks!