### PR TITLE
Support for sessions to save all workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Options:
   -d, --directory DIRECTORY  The directory to save the workspace to.
                              [default: ~/.i3/i3-resurrect]
   -p, --profile TEXT         The profile to save the workspace to.
+  -S, --session TEXT         The session to save all the workspaces to.
   -s, --swallow TEXT         The swallow criteria to use.
                              [options: class,instance,title,window_role]
                              [default: class,instance]
@@ -169,6 +170,7 @@ Options:
   -d, --directory DIRECTORY  The directory to restore the workspace from.
                              [default: ~/.i3/i3-resurrect]
   -p, --profile TEXT         The profile to restore the workspace from.
+  -S, --session TEXT         The session to restore all workspaces from.
   --layout-only              Only restore layout.
   --programs-only            Only restore running programs.
 
@@ -191,6 +193,7 @@ Options:
   -d, --directory DIRECTORY  The directory to delete from.
                              [default: ~/.i3/i3-resurrect]
   -p, --profile TEXT         The profile to delete.
+  -S, --session TEXT         The session to delete.
   --layout-only              Only delete saved layout.
   --programs-only            Only delete saved programs.
 ```

--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -39,6 +39,9 @@ def main():
     "--profile", "-p", default=None, help=("The profile to save the workspace to.")
 )
 @click.option(
+    "--session", "-S", default=None, help="Save all workspaces."
+)
+@click.option(
     "--swallow",
     "-s",
     default="class,instance",
@@ -57,27 +60,35 @@ def main():
     flag_value="programs_only",
     help="Only save running programs.",
 )
-def save_workspace(workspace, numeric, directory, profile, swallow, target):
+def save_workspace(workspace, numeric, directory, profile, session, swallow, target):
     """
     Save an i3 workspace's layout and running programs to a file.
     """
-    if workspace is None:
-        i3 = i3ipc.Connection()
-        workspace = i3.get_tree().find_focused().workspace().name
+    workspaces = []
+    directory = util.resolve_directory(directory, profile, session)
 
-    directory = util.resolve_directory(directory, profile)
+    if session is not None:
+        i3 = i3ipc.Connection()
+        workspaces = i3.get_workspaces()
+        directory = directory / session
+    elif workspace is None:
+        i3 = i3ipc.Connection()
+        workspace = i3.get_tree().find_focused().workspace()
+        workspaces = [workspace]
 
     # Create directory if non-existent.
     Path(directory).mkdir(parents=True, exist_ok=True)
 
-    if target != "programs_only":
-        # Save workspace layout to file.
-        swallow_criteria = swallow.split(",")
-        layout.save(workspace, numeric, directory, profile, swallow_criteria)
+    for ws in workspaces:
 
-    if target != "layout_only":
-        # Save running programs to file.
-        programs.save(workspace, numeric, directory, profile)
+        if target != "programs_only":
+            # Save workspace layout to file.
+            swallow_criteria = swallow.split(",")
+            layout.save(ws.name, numeric, directory, profile, swallow_criteria)
+
+        if target != "layout_only":
+            # Save running programs to file.
+            programs.save(ws.name, numeric, directory, profile)
 
 
 @main.command("restore")
@@ -98,6 +109,9 @@ def save_workspace(workspace, numeric, directory, profile, swallow, target):
     "--profile", "-p", default=None, help=("The profile to restore the workspace from.")
 )
 @click.option(
+    "--session", "-S", default=None, help=("The session to restore the workspace from.")
+)
+@click.option(
     "--layout-only", "target", flag_value="layout_only", help="Only restore layout."
 )
 @click.option(
@@ -106,39 +120,52 @@ def save_workspace(workspace, numeric, directory, profile, swallow, target):
     flag_value="programs_only",
     help="Only restore running programs.",
 )
-def restore_workspace(workspace, numeric, directory, profile, target):
+def restore_workspace(workspace, numeric, directory, profile, session, target):
     """
     Restore i3 workspace layout and programs.
     """
     i3 = i3ipc.Connection()
+    workspaces = []
 
     if workspace is None:
         workspace = i3.get_tree().find_focused().workspace().name
 
-    directory = util.resolve_directory(directory, profile)
+    directory = util.resolve_directory(directory, profile, session)
 
     if numeric and not workspace.isdigit():
         util.eprint("Invalid workspace number.")
         sys.exit(1)
 
-    # Get layout name from file.
-    workspace_layout = layout.read(workspace, directory, profile)
-    if "name" in workspace_layout and profile is None:
-        workspace_name = workspace_layout["name"]
+    if session is not None:
+        directory = directory / session
+        # Error check if directory exists
+        for file in directory.iterdir():
+            if "_layout" not in file.name:
+                continue
+            workspaces.append(file.name.split("_")[1])
     else:
-        workspace_name = workspace
+        workspaces.append(workspace)
 
-    # Switch to the workspace which we are loading.
-    i3.command(f'workspace --no-auto-back-and-forth "{workspace_name}"')
+    for ws in workspaces:
 
-    if target != "programs_only":
-        # Load workspace layout.
-        layout.restore(workspace_name, workspace_layout)
+        # Get layout name from file.
+        workspace_layout = layout.read(ws, directory, profile)
+        if "name" in workspace_layout and profile is None:
+            workspace_name = workspace_layout["name"]
+        else:
+            workspace_name = ws
 
-    if target != "layout_only":
-        # Restore programs.
-        saved_programs = programs.read(workspace, directory, profile)
-        programs.restore(workspace_name, saved_programs)
+        # Switch to the workspace which we are loading.
+        i3.command(f'workspace --no-auto-back-and-forth "{workspace_name}"')
+
+        if target != "programs_only":
+            # Load workspace layout.
+            layout.restore(workspace_name, workspace_layout)
+
+        if target != "layout_only":
+            # Restore programs.
+            saved_programs = programs.read(ws, directory, profile)
+            programs.restore(workspace_name, saved_programs)
 
 
 @main.command("ls")
@@ -150,7 +177,7 @@ def restore_workspace(workspace, numeric, directory, profile, target):
     help="The directory to search in.\n[default: ~/.i3/i3-resurrect]",
 )
 @click.argument(
-    "item", type=click.Choice(["workspaces", "profiles"]), default="workspaces"
+    "item", type=click.Choice(["workspaces", "profiles", "sessions"]), default="workspaces"
 )
 def list_workspaces(directory, item):
     """
@@ -170,7 +197,7 @@ def list_workspaces(directory, item):
         workspaces = natsorted(workspaces)
         for workspace in workspaces:
             print(workspace)
-    else:
+    elif item == "profiles":
         directory = directory / "profiles"
         profiles = []
         try:
@@ -185,6 +212,25 @@ def list_workspaces(directory, item):
                 print(profile)
         except FileNotFoundError:
             print("No profiles found")
+    else:
+        directory = directory / "sessions"
+        sessions = []
+        try:
+            for entry in directory.iterdir():
+                if entry.is_dir():
+                    name = entry.name
+                    sessions.append(f"Session {name}")
+                    for file in (directory/name).iterdir():
+                        if file.is_file():
+                            name = file.name
+                            session = name[: name.rfind("_")]
+                            file_type = name[name.rfind("_") + 1 : name.index(".json")]
+                            sessions.append(f"Workspace {session} {file_type}")
+            sessions = natsorted(sessions)
+            for session in sessions:
+                print(session)
+        except FileNotFoundError:
+            print("No sessions found")
 
 
 @main.command("rm")
@@ -197,6 +243,7 @@ def list_workspaces(directory, item):
     help="The directory to delete from.\n[default: ~/.i3/i3-resurrect]",
 )
 @click.option("--profile", "-p", default=None, help=("The profile to delete."))
+@click.option("--session", "-S", default=None, help=("The session to delete."))
 @click.option(
     "--layout-only",
     "target",
@@ -209,13 +256,20 @@ def list_workspaces(directory, item):
     flag_value="programs_only",
     help="Only delete saved programs.",
 )
-def remove(workspace, directory, profile, target):
+def remove(workspace, directory, profile, session, target):
     """
     Remove saved layout or programs.
     """
-    directory = util.resolve_directory(directory, profile)
+    directory = util.resolve_directory(directory, profile, session)
 
-    if profile is not None:
+    if session is not None:
+        folder = Path(directory) / session
+        for file in folder.rglob('*'):
+            if file.is_file():
+                file.unlink()
+        folder.rmdir()
+        return
+    elif profile is not None:
         programs_filename = f"{profile}_programs.json"
         layout_filename = f"{profile}_layout.json"
     elif workspace is not None:
@@ -223,7 +277,7 @@ def remove(workspace, directory, profile, target):
         programs_filename = f"workspace_{workspace_id}_programs.json"
         layout_filename = f"workspace_{workspace_id}_layout.json"
     else:
-        util.eprint("Either --profile or --workspace must be specified.")
+        util.eprint("--session, --profile or --workspace must be specified.")
         sys.exit(1)
     programs_file = Path(directory) / programs_filename
     layout_file = Path(directory) / layout_filename

--- a/i3_resurrect/main.py
+++ b/i3_resurrect/main.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import click
 import i3ipc
 import shutil
-from natsort import natsorted
 
 from . import config
 from . import layout

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -1,4 +1,5 @@
 import sys
+from natsort import natsorted
 from os.path import expandvars
 from pathlib import Path
 
@@ -32,3 +33,36 @@ def resolve_directory(directory, profile=None, session=None):
     if session is not None:
         directory = directory / "sessions"
     return directory
+
+
+def resolve_filetype(file):
+    """
+    Extract from file name if it is a layout of a program file.
+    """
+    name = file.name
+    name = name[name.index("_") + 1 :]
+    file_type = name[name.rfind("_") + 1 : name.index(".json")]
+    return file_type
+
+
+def resolve_workspace_name(file, is_profile=False):
+    """
+    Extract the name of the workspace or the profile from the file name.
+    """
+    name = file.name
+    if not is_profile:
+        name = name[name.index("_") + 1 :]
+    workspace = name[: name.rfind("_")]
+    return workspace
+
+
+def get_list_of_workspaces(directory, is_profile=False):
+    """
+    Generate a list of all the workspaces or profiles present in a directory
+    """
+    workspaces = []
+    for entry in directory.iterdir():
+        if entry.is_file():
+            workspaces.append(f'{resolve_workspace_name(entry, is_profile)} {resolve_filetype(entry)}')
+    workspaces = natsorted(workspaces)
+    return workspaces

--- a/i3_resurrect/util.py
+++ b/i3_resurrect/util.py
@@ -25,8 +25,10 @@ def filename_filter(filename):
     return filename
 
 
-def resolve_directory(directory, profile=None):
+def resolve_directory(directory, profile=None, session=None):
     directory = Path(expandvars(directory)).expanduser()
     if profile is not None:
         directory = directory / "profiles"
+    if session is not None:
+        directory = directory / "sessions"
     return directory


### PR DESCRIPTION
Added support to save all workspaces using one command. This change uses the flag `--session` or `-S` with a session name to store the session. The session is stored in a folder structure shown below:-
<img width="539" height="291" alt="image" src="https://github.com/user-attachments/assets/98f756a7-c7e8-46c3-988c-3b4e36002cbb" />
Where "Default" is the name of the session.

Let me know if I need to change anything.